### PR TITLE
Redefine the length error code

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -27,6 +27,8 @@
 
 // Error
 enum Error {
+	// Length error
+	LENGTH_ERROR = 0x6700,
 
 	// Unknown class error
 	UNKNOWN_CLASS_ERROR = ERR_APP_RANGE_01 + ERR_GEN_SUB_01,

--- a/src/continue_decrypting_slate.c
+++ b/src/continue_decrypting_slate.c
@@ -72,7 +72,7 @@ void processContinueDecryptingSlateRequest(unsigned short *responseLength, __att
 	if(willResponseOverflow(*responseLength, sizeof(encryptedData))) {
 	
 		// Throw length error
-		THROW(ERR_APD_LEN);
+		THROW(LENGTH_ERROR);
 	}
 	
 	// Append encrypted data to response

--- a/src/continue_encrypting_slate.c
+++ b/src/continue_encrypting_slate.c
@@ -47,7 +47,7 @@ void processContinueEncryptingSlateRequest(unsigned short *responseLength, __att
 	if(willResponseOverflow(*responseLength, sizeof(encryptedData))) {
 	
 		// Throw length error
-		THROW(ERR_APD_LEN);
+		THROW(LENGTH_ERROR);
 	}
 	
 	// Append encrypted data to response

--- a/src/continue_transaction_get_encrypted_secret_nonce.c
+++ b/src/continue_transaction_get_encrypted_secret_nonce.c
@@ -117,7 +117,7 @@ void processContinueTransactionGetEncryptedSecretNonceRequest(unsigned short *re
 	if(willResponseOverflow(*responseLength, encryptedSecretNonceAndSignatureLength)) {
 	
 		// Throw length error
-		THROW(ERR_APD_LEN);
+		THROW(LENGTH_ERROR);
 	}
 	
 	// Append encrypted secret nonce and signature to response

--- a/src/continue_transaction_get_public_key.c
+++ b/src/continue_transaction_get_public_key.c
@@ -82,7 +82,7 @@ void processContinueTransactionGetPublicKeyRequest(unsigned short *responseLengt
 	if(willResponseOverflow(*responseLength, sizeof(publicKey))) {
 	
 		// Throw length error
-		THROW(ERR_APD_LEN);
+		THROW(LENGTH_ERROR);
 	}
 	
 	// Append public key to response

--- a/src/continue_transaction_get_public_nonce.c
+++ b/src/continue_transaction_get_public_nonce.c
@@ -82,7 +82,7 @@ void processContinueTransactionGetPublicNonceRequest(unsigned short *responseLen
 	if(willResponseOverflow(*responseLength, sizeof(publicNonce))) {
 	
 		// Throw length error
-		THROW(ERR_APD_LEN);
+		THROW(LENGTH_ERROR);
 	}
 	
 	// Append public nonce to response

--- a/src/finish_decrypting_slate.c
+++ b/src/finish_decrypting_slate.c
@@ -75,7 +75,7 @@ void processFinishDecryptingSlateRequest(unsigned short *responseLength, __attri
 	if(willResponseOverflow(*responseLength, sizeof(slate.sessionKey))) {
 	
 		// Throw length error
-		THROW(ERR_APD_LEN);
+		THROW(LENGTH_ERROR);
 	}
 	
 	// Append slate session key to response

--- a/src/finish_encrypting_slate.c
+++ b/src/finish_encrypting_slate.c
@@ -42,7 +42,7 @@ void processFinishEncryptingSlateRequest(unsigned short *responseLength, __attri
 	if(willResponseOverflow(*responseLength, sizeof(tag))) {
 	
 		// Throw length error
-		THROW(ERR_APD_LEN);
+		THROW(LENGTH_ERROR);
 	}
 	
 	// Append tag to response

--- a/src/finish_transaction.c
+++ b/src/finish_transaction.c
@@ -743,7 +743,7 @@ void processFinishTransactionUserInteraction(unsigned short *responseLength) {
 	if(willResponseOverflow(*responseLength, sizeof(signature) + paymentProofLength)) {
 	
 		// Throw length error
-		THROW(ERR_APD_LEN);
+		THROW(LENGTH_ERROR);
 	}
 	
 	// Append signature to response

--- a/src/get_address.c
+++ b/src/get_address.c
@@ -134,7 +134,7 @@ void processGetAddressRequest(unsigned short *responseLength, __attribute__((unu
 	if(willResponseOverflow(*responseLength, addressLength)) {
 	
 		// Throw length error
-		THROW(ERR_APD_LEN);
+		THROW(LENGTH_ERROR);
 	}
 	
 	// Append address to response

--- a/src/get_bulletproof_components.c
+++ b/src/get_bulletproof_components.c
@@ -234,7 +234,7 @@ void processGetBulletproofComponentsRequest(unsigned short *responseLength, __at
 	if(willResponseOverflow(*responseLength, sizeof(bulletproofTauX) + sizeof(bulletproofTOne) + sizeof(bulletproofTTwo))) {
 	
 		// Throw length error
-		THROW(ERR_APD_LEN);
+		THROW(LENGTH_ERROR);
 	}
 
 	// Append bulletproof tau x, t one, and t two to response

--- a/src/get_commitment.c
+++ b/src/get_commitment.c
@@ -116,7 +116,7 @@ void processGetCommitmentRequest(unsigned short *responseLength, __attribute__((
 	if(willResponseOverflow(*responseLength, sizeof(commitment))) {
 	
 		// Throw length error
-		THROW(ERR_APD_LEN);
+		THROW(LENGTH_ERROR);
 	}
 
 	// Append commitment to response

--- a/src/get_mqs_timestamp_signature.c
+++ b/src/get_mqs_timestamp_signature.c
@@ -168,7 +168,7 @@ void processGetMqsTimestampSignatureUserInteraction(unsigned short *responseLeng
 	if(willResponseOverflow(*responseLength, signatureLength)) {
 	
 		// Throw length error
-		THROW(ERR_APD_LEN);
+		THROW(LENGTH_ERROR);
 	}
 	
 	// Append signature to response

--- a/src/get_root_public_key.c
+++ b/src/get_root_public_key.c
@@ -80,7 +80,7 @@ void processGetRootPublicKeyUserInteraction(unsigned short *responseLength) {
 			if(willResponseOverflow(*responseLength, sizeof(rootPublicKey))) {
 			
 				// Throw length error
-				THROW(ERR_APD_LEN);
+				THROW(LENGTH_ERROR);
 			}
 			
 			// Append root public key to response

--- a/src/get_seed_cookie.c
+++ b/src/get_seed_cookie.c
@@ -83,7 +83,7 @@ void processGetSeedCookieRequest(unsigned short *responseLength, __attribute__((
 	if(willResponseOverflow(*responseLength, sizeof(seedCookie))) {
 	
 		// Throw length error
-		THROW(ERR_APD_LEN);
+		THROW(LENGTH_ERROR);
 	}
 	
 	// Append seed cookie to response

--- a/src/get_tor_certificate_signature.c
+++ b/src/get_tor_certificate_signature.c
@@ -300,7 +300,7 @@ void processGetTorCertificateSignatureUserInteraction(unsigned short *responseLe
 	if(willResponseOverflow(*responseLength, sizeof(signature))) {
 	
 		// Throw length error
-		THROW(ERR_APD_LEN);
+		THROW(LENGTH_ERROR);
 	}
 	
 	// Append signature to response

--- a/src/main.c
+++ b/src/main.c
@@ -155,7 +155,7 @@
 					if(requestLength >= sizeof(G_io_apdu_buffer)) {
 					
 						// Throw length error
-						THROW(ERR_APD_LEN);
+						THROW(LENGTH_ERROR);
 					}
 					
 					// Get request and/or send response
@@ -175,7 +175,7 @@
 					if(requestLength >= sizeof(G_io_apdu_buffer)) {
 					
 						// Throw length error
-						THROW(ERR_APD_LEN);
+						THROW(LENGTH_ERROR);
 					}
 					
 					// Check if pin is not validated
@@ -221,7 +221,7 @@
 							if(willResponseOverflow(responseLength, sizeof(uint16_t))) {
 							
 								// Throw length error
-								THROW(ERR_APD_LEN);
+								THROW(LENGTH_ERROR);
 							}
 							
 							// Otherwise

--- a/src/process_requests.c
+++ b/src/process_requests.c
@@ -317,10 +317,10 @@ void processRequest(unsigned short requestLength, volatile unsigned short *respo
 		}
 		
 		// Catch length error
-		CATCH(ERR_APD_LEN) {
+		CATCH(LENGTH_ERROR) {
 		
 			// Throw length error
-			THROW(ERR_APD_LEN);
+			THROW(LENGTH_ERROR);
 		}
 		
 		// Catch other errors
@@ -463,10 +463,10 @@ void processUserInteraction(size_t instruction, bool isApprovedResult, bool show
 		}
 		
 		// Catch length error
-		CATCH(ERR_APD_LEN) {
+		CATCH(LENGTH_ERROR) {
 		
 			// Throw length error
-			THROW(ERR_APD_LEN);
+			THROW(LENGTH_ERROR);
 		}
 		
 		// Catch other errors
@@ -497,7 +497,7 @@ void processUserInteraction(size_t instruction, bool isApprovedResult, bool show
 					if(willResponseOverflow(responseLength, sizeof(uint16_t))) {
 				
 						// Throw length error
-						THROW(ERR_APD_LEN);
+						THROW(LENGTH_ERROR);
 					}
 					
 					// Otherwise

--- a/src/start_encrypting_slate.c
+++ b/src/start_encrypting_slate.c
@@ -204,7 +204,7 @@ void processStartEncryptingSlateRequest(unsigned short *responseLength, __attrib
 	if(willResponseOverflow(*responseLength, sizeof(nonce) + saltLength)) {
 	
 		// Throw length error
-		THROW(ERR_APD_LEN);
+		THROW(LENGTH_ERROR);
 	}
 	
 	// Append nonce to response	


### PR DESCRIPTION
Redefine the length error code as `ERR_APD_LEN` will no longer be available in the SDK.